### PR TITLE
Add JsonDefaults for consistent JSON serialization

### DIFF
--- a/src/QuizItEasy.API/Program.cs
+++ b/src/QuizItEasy.API/Program.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using QuizItEasy.API.Common.Extensions;
@@ -20,12 +19,6 @@ builder.Services.AddEndpoints(QuizItEasy.API.AssemblyReference.Assembly);
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy => policy.WithOrigins("http://localhost:4200"));
-});
-
-builder.Services.ConfigureHttpJsonOptions(options =>
-{
-    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-    options.SerializerOptions.WriteIndented = true;
 });
 
 var app = builder.Build();

--- a/src/QuizItEasy.API/Program.cs
+++ b/src/QuizItEasy.API/Program.cs
@@ -22,7 +22,8 @@ builder.Services.AddCors(options =>
     options.AddDefaultPolicy(policy => policy.WithOrigins("http://localhost:4200"));
 });
 
-builder.Services.ConfigureHttpJsonOptions(options => {
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
     options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
     options.SerializerOptions.WriteIndented = true;
 });

--- a/src/QuizItEasy.API/Program.cs
+++ b/src/QuizItEasy.API/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using QuizItEasy.API.Common.Extensions;
@@ -19,6 +20,11 @@ builder.Services.AddEndpoints(QuizItEasy.API.AssemblyReference.Assembly);
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy => policy.WithOrigins("http://localhost:4200"));
+});
+
+builder.Services.ConfigureHttpJsonOptions(options => {
+    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+    options.SerializerOptions.WriteIndented = true;
 });
 
 var app = builder.Build();

--- a/src/QuizItEasy.Application/Common/Utility/JsonDefaults.cs
+++ b/src/QuizItEasy.Application/Common/Utility/JsonDefaults.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json;
+
+namespace QuizItEasy.Application.Common.Utility;
+
+public static class JsonDefaults
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+}

--- a/src/QuizItEasy.Application/Common/Utility/QuestionToJsonResolvers/MultiSelectQuestionResolver.cs
+++ b/src/QuizItEasy.Application/Common/Utility/QuestionToJsonResolvers/MultiSelectQuestionResolver.cs
@@ -21,6 +21,6 @@ internal class MultiSelectQuestionResolver : IQuestionToJsonResolver
 
         var multiSelectResponse = multiSelectQuestion.Adapt<MultiSelectQuestionResponse>();
 
-        return new QuestionResponse(QuestionDiscriminator, JsonSerializer.Serialize(multiSelectResponse));
+        return new QuestionResponse(QuestionDiscriminator, JsonSerializer.Serialize(multiSelectResponse, JsonDefaults.Options));
     }
 }

--- a/src/QuizItEasy.Application/Common/Utility/QuestionToJsonResolvers/SingleSelectQuestionResolver.cs
+++ b/src/QuizItEasy.Application/Common/Utility/QuestionToJsonResolvers/SingleSelectQuestionResolver.cs
@@ -21,6 +21,6 @@ internal class SingleSelectQuestionResolver : IQuestionToJsonResolver
 
         var singleSelectResponse = singleSelectQuestion.Adapt<SingleSelectQuestionResponse>();
 
-        return new QuestionResponse(QuestionDiscriminator, JsonSerializer.Serialize(singleSelectResponse));
+        return new QuestionResponse(QuestionDiscriminator, JsonSerializer.Serialize(singleSelectResponse, JsonDefaults.Options));
     }
 }


### PR DESCRIPTION
Introduce a new `JsonDefaults` class to encapsulate default `JsonSerializerOptions`, setting camel case naming and indented formatting. Update `MultiSelectQuestionResolver` and `SingleSelectQuestionResolver` to use these options, and configure HTTP JSON options in `Program.cs` for enhanced consistency and readability of JSON output.